### PR TITLE
by default we should now auth reads

### DIFF
--- a/ansible/librarian_roles/bcoe.npme/files/service.json
+++ b/ansible/librarian_roles/bcoe.npme/files/service.json
@@ -73,7 +73,7 @@
       "default": "/etc/npme/packages",
       "description": "folder on HD to store package binaries"
     },
-    "--auth-fetch": "false",
+    "--auth-fetch": "true",
     "--shared-fetch-secret": "change-me-to-a-secure-token"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npme-ansible",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "description": "Wraps the npm Enterprises Ansible script.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
We were originally defaulting this to false due to a client issue. Now that the client always passes the authToken, we should default to authing both reads and writes.
