### PR TITLE
don't abort the install if we're missing a dependency, keep on truckin'

### DIFF
--- a/ansible/librarian_roles/bcoe.npme/tasks/centos65/couchdb.yml
+++ b/ansible/librarian_roles/bcoe.npme/tasks/centos65/couchdb.yml
@@ -1,6 +1,7 @@
 ---
   - name: install dependencies
     sudo: yes
+    ignore_errors: true
     yum: name={{ item }} state=installed
     with_items:
       - autoconf


### PR DESCRIPTION
This allows us to install some modules on Centos manually.